### PR TITLE
Expose POS tagging from CLTK core

### DIFF
--- a/api_json.py
+++ b/api_json.py
@@ -8,7 +8,7 @@ from flask import request  # for getting query string
 # eg: request.args.get('user') will get '?user=some-value'
 from flask_restful import Resource, Api
 from util.jsonp import jsonp
-
+from metadata.pos.views import POSTagger
 
 app = Flask(__name__)
 api = Api(app)
@@ -161,6 +161,9 @@ api.add_resource(Lang, '/lang')
 # http://localhost:5000/lang/greek/corpus/perseus/author/homer/text/odyssey?chunk1=1&chunk2=1
 api.add_resource(Text, '/lang/<string:lang>/corpus/<string:corpus>/author/<string:author>/text/<string:work>')
 #api.add_resource(Text, '/lang/<string:lang>/corpus/<string:corpus>/author/<string:author>/text/<string:work>/<string:chunk1>')
+
+# CLTK core
+api.add_resource(POSTagger, '/core/pos', endpoint='pos')
 
 # simple examples
 api.add_resource(TodoSimple, '/todo/<string:todo_id>')

--- a/metadata/pos/constants.py
+++ b/metadata/pos/constants.py
@@ -1,0 +1,4 @@
+# list of available POS tagging methods in CLTK
+POS_METHODS = {'greek': ['unigram', 'bigram', 'trigram', 'ngram123', 'tnt'],
+               'latin': ['unigram', 'bigram', 'trigram', 'ngram123', 'tnt']}
+DEFAULT_POS_METHOD = 'ngram123'

--- a/metadata/pos/views.py
+++ b/metadata/pos/views.py
@@ -1,0 +1,47 @@
+from .constants import POS_METHODS, DEFAULT_POS_METHOD
+from cltk.tag.pos import POSTag
+from flask_restful import Resource, reqparse
+
+"""
+    GET     /core/pos                           View available POS tagging methods
+
+    POST    /core/pos                           Return POS tags for the given string
+            Data: {'string': string to tag,     using the specified langauge and
+                   'lang':   language           tagging method.
+                   'method': tagging method}
+"""
+class POSTagger(Resource):
+    def get(self):
+        return {'methods': POS_METHODS}
+
+    def post(self):
+        self.reqparse = reqparse.RequestParser()
+        self.reqparse.add_argument('string', required=True)
+        self.reqparse.add_argument('lang', required=True, choices=POS_METHODS.keys())
+        self.reqparse.add_argument('method', required=False,
+                                   default=DEFAULT_POS_METHOD)
+
+        args = self.reqparse.parse_args()
+        string = args['string']
+        lang = args['lang']
+        method = args['method']
+
+        if method not in POS_METHODS[lang]:
+            return {'message': {'method': method + ' is not a valid choice'}}
+
+        tagger = POSTag(lang)
+        tagged = []
+        if method == 'unigram':
+            tagged = tagger.tag_unigram(string)
+        elif method == 'bigram':
+            tagged = tagger.tag_bigram(string)
+        elif method == 'trigram':
+            tagged = tagger.tag_trigram(string)
+        elif method == 'ngram123':
+            tagged = tagger.tag_ngram_123_backoff(string)
+        elif method == 'tnt':
+            tagged = tagger.tag_tnt(string)
+
+        return {'tags': [{'word': word, 'tag': tag}
+                         if tag is not None else {'word': word, 'tag': 'None'}
+                         for word, tag in tagged]}


### PR DESCRIPTION
## Summary

The following PR adds the `/pos/core` endpoint. It addresses https://github.com/cltk/cltk_api/issues/25.

Supported POS languages and methods are in `metadata/pos/constants.py`. These can be listed via a `GET /pos/core` request.

A string can be tagged via a `POST /pos/core` request with the following arguments specified via a JSON post body:
- `string`: The string to tag.
- `lang`: The language of the string.
- `method`: The POS tagging method (`ngram123` by default).

Validation is performed on the language and method arguments using the ones specified in `metadata/pos/constants.py`. It checks if the specified language is valid, and if the specified method is valid for that language.
## Examples

Before trying these out, start the server with `python api_json.py`.

_Getting the list of languages and POS tagging methods_

```
$ curl localhost:5000/core/pos
{
    "methods": {
        "greek": [
            "unigram",
            "bigram",
            "trigram",
            "ngram123",
            "tnt"
        ],
        "latin": [
            "unigram",
            "bigram",
            "trigram",
            "ngram123",
            "tnt"
        ]
    }
}
```

_Try POS tagging with an invalid language but valid method_

```
$ curl -X POST -H "Content-Type: application/json" -d '{"string":"Gallia est omnis divisa in partes tres", "lang":"random", "method":"ngram123"}' localhost:5000/core/pos
{
    "message": {
        "lang": "random is not a valid choice"
    }
}
```

_Try POS tagging with a valid language but invalid method_

```
$ curl -X POST -H "Content-Type: application/json" -d '{"string":"Gallia est omnis divisa in partes tres", "lang":"latin", "method":"random"}' localhost:5000/core/pos
{
    "message": {
        "method": "random is not a valid choice"
    }
}
```

_Try POS tagging with a valid language and method_

```
$ curl -X POST -H "Content-Type: application/json" -d '{"string":"Gallia est omnis divisa in partes tres", "lang":"latin", "method":"ngram123"}' localhost:5000/core/pos
{
    "tags": [
        {
            "tag": "None",
            "word": "Gallia"
        },
        {
            "tag": "V3SPIA---",
            "word": "est"
        },
        {
            "tag": "A-S---MN-",
            "word": "omnis"
        },
        {
            "tag": "T-PRPPNN-",
            "word": "divisa"
        },
        {
            "tag": "R--------",
            "word": "in"
        },
        {
            "tag": "N-P---FA-",
            "word": "partes"
        },
        {
            "tag": "M--------",
            "word": "tres"
        }
    ]
}
```
## Issues
- I need to add more tests, but I think they will appear really similar to the [POS tagging tests in CLTK](https://github.com/cltk/cltk/blob/5ecc261afc5dd9596126dfc77b1983a4ad8cc63b/cltk/tests/test_tag.py). Is there a good way to remain in sync with the CLTK core without repeating ourselves?
- Are there specific methods that apply to specific languages (I have assumed this), or is will every method be implemented for all available languages?
