### PR TITLE
Adding API endpoint for word definitions

### DIFF
--- a/api_json.py
+++ b/api_json.py
@@ -9,6 +9,8 @@ from flask import request  # for getting query string
 from flask_restful import Resource, Api
 from util.jsonp import jsonp
 
+from metadata.definition.views import Definition
+
 
 app = Flask(__name__)
 api = Api(app)
@@ -161,6 +163,9 @@ api.add_resource(Lang, '/lang')
 # http://localhost:5000/lang/greek/corpus/perseus/author/homer/text/odyssey?chunk1=1&chunk2=1
 api.add_resource(Text, '/lang/<string:lang>/corpus/<string:corpus>/author/<string:author>/text/<string:work>')
 #api.add_resource(Text, '/lang/<string:lang>/corpus/<string:corpus>/author/<string:author>/text/<string:work>/<string:chunk1>')
+
+# http://localhost:5000/lang/latin/define/abante
+api.add_resource(Definition, '/lang/<string:lang>/define/<string:word>')
 
 # simple examples
 api.add_resource(TodoSimple, '/todo/<string:todo_id>')

--- a/metadata/definition/views.py
+++ b/metadata/definition/views.py
@@ -1,0 +1,25 @@
+from flask_restful import Resource
+import json
+import os
+
+class Definition(Resource):
+
+	# Directory where the definitions json file will be present
+	BASE_DIR = ""
+	# File name suffix for the json files
+	DATA_FILE_SUFFFIX = "-analyses.json"
+
+	'''
+	GET 	/lang/<string:lang>/define/<string:word>
+			Return the available definitions for a word of given language
+	'''
+	def get(self, lang, word):
+		# File name would something like "latin-analyses.json"
+		filename = lang + self.DATA_FILE_SUFFFIX
+		file = os.path.join(self.BASE_DIR, filename)
+		with open(file, "r") as infile:
+			word_list = json.load(infile)
+		try:
+			return word_list[word]
+		except KeyError as e:
+			return "No definitions available"


### PR DESCRIPTION
This uses the definitions json files to provide API endpoints.
I will update the `BASE_DIR` path once we decide where to store those json files.
Signed-off-by: Suhaib Khan suheb.work@gmail.com
